### PR TITLE
update sentry repository to new location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	branch = develop
 [submodule "apache-sentry"]
 	path = apache-sentry
-	url = git://git.apache.org/sentry.git
+	url = https://gitbox.apache.org/repos/asf/sentry.git
 	branch = branch-1.7.0
 [submodule "app-artifacts/mmds"]
 	path = app-artifacts/mmds


### PR DESCRIPTION
Sentry repository has been moved, per http://mail-archives.apache.org/mod_mbox/sentry-dev/201901.mbox/%3CCAHQna8d1PG4QMm-iMsJcd3Kb0AzATET9Tbk2HscCPsCxu7dhsw%40mail.gmail.com%3E