### PR TITLE
- Use relative URL for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,20 @@
 [submodule "cdap"]
 	path = cdap
-	url = https://github.com/cdapio/cdap.git
+	url = ../cdap.git
 	branch = develop
 [submodule "app-artifacts/hydrator-plugins"]
 	path = app-artifacts/hydrator-plugins
-	url = https://github.com/cdapio/hydrator-plugins.git
+	url = ../hydrator-plugins.git
 	branch = develop
 [submodule "security-extensions/cdap-security-extn"]
 	path = security-extensions/cdap-security-extn
-	url = https://github.com/cdapio/cdap-security-extn.git
+	url = ../cdap-security-extn.git
 	branch = develop
-[submodule "apache-sentry"]
-	path = apache-sentry
-	url = https://gitbox.apache.org/repos/asf/sentry.git
-	branch = branch-1.7.0
 [submodule "app-artifacts/mmds"]
 	path = app-artifacts/mmds
-	url = https://github.com/cdap-solutions/mmds.git
+	url = ../../cdap-solutions/mmds.git
 	branch = develop
 [submodule "app-artifacts/dre"]
 	path = app-artifacts/dre
-	url = https://github.com/cdap-solutions/dre.git
+	url = ../../cdap-solutions/dre.git
 	branch = develop

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <module>app-artifacts/dre</module>
     <module>app-artifacts/hydrator-plugins</module>
     <module>app-artifacts/mmds</module>
-    <module>security-extensions/cdap-security-extn</module>
     <module>cdap</module>
   </modules>
 
@@ -46,4 +45,16 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>security-ext</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>security-extensions/cdap-security-extn</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
- Delete the apache-sentry source
-- It is available from maven, no need to build it anymore
- Move building of security extension into a profile