### PR TITLE
[CDAP-18024] Create cdap user and owned data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,10 @@ ENV HADOOP_HOME=/opt/hadoop/hadoop-2.9.2
 ENV SPARK_HOME=/opt/spark/spark-3.1.1-bin-without-hadoop
 ENV SPARK_COMPAT=spark3_2.12
 ENV HBASE_VERSION=1.2
+
+RUN groupadd -g 1000 cdap
+RUN useradd -m -u 1000 -g 1000 cdap
+RUN mkdir /data
+RUN chown 1000:1000 /data
+RUN chmod 766 /data
 ENTRYPOINT ["/opt/cdap/master/bin/cdap", "run"]


### PR DESCRIPTION
Creates a CDAP user and data directory to be used for running as non-root user. For additional details, see [CDAP-18024](https://cdap.atlassian.net/browse/CDAP-18024).