### PR TITLE
Add metricswriter extension to CDAP build.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,8 @@
 	path = app-artifacts/delta-transformation
 	url = ../../data-integrations/delta-transformation.git
 	branch = develop
+[submodule "metricswriters-extensions/metrics-writer-extension"]
+	path = metricswriters-extensions/metrics-writer-extension
+	url = ../metrics-writer-extension.git
+        branch = develop
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
   mvn install -B -V -Ddocker.skip=true -DskipTests -P templates,dist,k8s,!unit-tests \
     -Dadditional.artifacts.dir=$DIR/app-artifacts \
     -Dsecurity.extensions.dir=$DIR/security-extensions \
+    -Dmetricswriters.extensions.dir=$DIR/metricswriters-extensions \
     -Dui.build.name=cdap-non-optimized-full-build
 
 FROM openjdk:8-jdk AS run

--- a/maven.Dockerfile
+++ b/maven.Dockerfile
@@ -15,7 +15,7 @@
 
 # Dockerfile for building container for building CDAP.
 # It populate maven cache with dependencies needed for building CDAP.
-FROM maven:3-jdk-8 AS build
+FROM gcr.io/cloud-builders/mvn:3.5.0-jdk-8 AS build
 ENV MAVEN_OPTS -Xmx4096m -Dhttp.keepAlive=false
 WORKDIR /cdap/maven/
 COPY . /cdap/maven/

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <module>app-artifacts/database-plugins/cloudsql-postgresql-plugin</module>
     <module>app-artifacts/mmds</module>
     <module>cdap</module>
+    <module>metricswriters-extensions/metrics-writer-extension</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Add metricswriter extension to CDAP image .

- Add the `metricswriters-extensions/metrics-writer-extension` repo as submodule so that it maven builds can build this repo.
- Pass a new parameter `metricswriters.extensions.dir` to cdap build which will be used for packaging metricwriter in the ext folder
- Fix the mvn image in `maven.Dockerfile` to use maven 3.5.0 . `maven:3-jdk-8` uses a latest 3.8.x version that causes `Blocked mirror for repositories`