### PR TITLE
Make BUT workflow run on schedule on develop and release branches

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -3,14 +3,56 @@ on:
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
+    # workaround to run manual trigger for a particular branch
+    inputs:
+      branch:
+        description: "branch name on which workflow will be triggered"
+        required: true
+        default: "develop"
 
 env:
   TAG_NAME: latest
-  BRANCH_NAME: develop
 
 jobs:
+
+  set-branch-matrix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: set-matrix on schedule run
+        id: set-matrix-on-schedule-run
+        if: github.event_name != 'workflow_dispatch'
+        run: echo "::set-output name=matrix::{\"include\":[{\"branch\":\"develop\"},{\"branch\":\"release/6.6\"}, {\"branch\":\"release/6.7\"}]}"
+
+      - name: set-matrix on manual trigger
+        id: set-matrix-on-manual-trigger
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "::set-output name=matrix::{\"include\":[{\"branch\":\"${{ github.event.inputs.branch }}\"}]}"
+
+      - name: set-matrix-output
+        id: set-matrix-output
+        run: |
+          if [ -z "$MANUAL_TRIGGER_OUTPUT" ];
+          then
+            echo "::set-output name=matrix::${SCHEDULE_RUN_OUTPUT}"
+          else
+            echo "::set-output name=matrix::${MANUAL_TRIGGER_OUTPUT}"
+          fi
+        env:
+          MANUAL_TRIGGER_OUTPUT: ${{ steps.set-matrix-on-manual-trigger.outputs.matrix }}
+          SCHEDULE_RUN_OUTPUT: ${{ steps.set-matrix-on-schedule-run.outputs.matrix }}
+
+    outputs:
+      matrix: ${{ steps.set-matrix-output.outputs.matrix }}
+
   build:
+    needs: set-branch-matrix
     runs-on: cdapio-hub-k8-runner
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.set-branch-matrix.outputs.matrix) }}
+
     steps:
       - name: Get Secrets from GCP Secret Manager
         id: 'secrets'
@@ -27,11 +69,11 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-          path: cdap
-          ref: ${{env.BRANCH_NAME}}
+          path: cdap-build
+          ref: ${{ matrix.branch }}
 
       - name: Update Submodules
-        working-directory: cdap
+        working-directory: cdap-build
         run: |
           git submodule update --init --recursive --remote
 
@@ -44,17 +86,18 @@ jobs:
             ${{ runner.os }}-maven-${{ github.workflow }}
 
       - name: Run Tests
-        working-directory: ./cdap
-        run: MAVEN_OPTS="-Xmx16G" mvn test -Drat.skip=true -fae -T2C -U -V -am -amd -P templates,unit-tests --fail-at-end -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
+        working-directory: cdap-build
+        run: MAVEN_OPTS="-Xmx16G -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/cdap-build/oom.bin" mvn test -Drat.skip=true -fae -T2C -U -V -am -amd -P templates,unit-tests --fail-at-end -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
 
       - name: Archive build artifacts
         uses: actions/upload-artifact@v2.2.2
         if: always()
         with:
-          name: Build debug files
+          name: Build debug files - ${{ matrix.branch }}
           path: |
             **/target/rat.txt
             **/target/surefire-reports/*
+            /cdap-build/oom.bin
 
       - name: Surefire Report
         # Pinned 1.0.5 version
@@ -64,29 +107,18 @@ jobs:
           # GITHUB_TOKEN
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit: ${{ github.sha }}
+          check_name: Test Report - ${{ matrix.branch }}
 
       - name: Build Standalone
-        working-directory: ./cdap
+        working-directory: cdap-build
         run: MAVEN_OPTS="-Xmx12G" mvn -Drat.skip=true -e -T2C clean package -Dgpg.skip -DskipTests -Ddocker.skip=true -nsu -am -amd -P templates,dist,release -Dadditional.artifacts.dir=$(pwd)/app-artifacts -Dsecurity.extensions.dir=$(pwd)/security-extensions -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
 
       - name: Find Build Version
-        working-directory: ./cdap/cdap
+        working-directory: cdap-build/cdap
         run:  |
           export VERSION=$(ls cdap-standalone/target/cdap-sandbox*zip | cut --delimiter=- --fields="-3" --complement | rev | cut --delimiter="." --fields=1 --complement | rev)
           echo "CDAP_VERSION=${VERSION}"
           echo "CDAP_VERSION=${VERSION}" >> $GITHUB_ENV
-
-      - name: Set up tag name
-        if: ${{ env.BRANCH_NAME != 'develop' }}
-        run: |
-          echo "TAG_NAME=$CDAP_VERSION" >> $GITHUB_ENV
-      
-      - name: Upload CDAP Standalone
-        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
-        with:
-          repo_token: ${{secrets.GITHUB_TOKEN}}
-          automatic_release_tag: ${{env.TAG_NAME}}
-          files: ./cdap/cdap/cdap-standalone/target/cdap-sandbox-${{env.CDAP_VERSION}}.zip
 
       - name: Set up GPG conf
         run: |
@@ -101,10 +133,32 @@ jobs:
           GPG_PRIVATE_KEY: ${{ steps.secrets.outputs.CDAP_GPG_PRIVATE_KEY }}
 
       - name: Deploy Maven
-        working-directory: cdap
+        working-directory: cdap-build
         run: mvn deploy -B -V -DskipTests -DskipLocalStaging=true -Ddocker.skip=true -P templates,dist,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests -Dadditional.artifacts.dir=$(pwd)/app-artifacts -Dsecurity.extensions.dir=$(pwd)/security-extensions -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dgpg.passphrase=$CDAP_GPG_PASSPHRASE
         env:
           CDAP_OSSRH_USERNAME: ${{ steps.secrets.outputs.CDAP_OSSRH_USERNAME }}
           CDAP_OSSRH_PASSWORD: ${{ steps.secrets.outputs.CDAP_OSSRH_PASSWORD }}
           CDAP_GPG_PASSPHRASE: ${{ steps.secrets.outputs.CDAP_GPG_PASSPHRASE }}
           MAVEN_OPTS: "-Xmx12G"
+
+      - name: Build DEB Bundle
+        working-directory: cdap-build/cdap
+        run: |
+          mkdir -p cdap-distributions/target/deb-bundle-tmp
+          cd cdap-distributions/target/deb-bundle-tmp
+          cp ../../../*/target/*.deb .
+          tar zcf ../cdap-distributed-deb-bundle-${{env.CDAP_VERSION}}.tgz *.deb
+
+      - name: Set up tag name
+        if: ${{ matrix.branch }} != 'develop'
+        run: |
+          echo "TAG_NAME=$CDAP_VERSION" >> $GITHUB_ENV
+
+      - name: Upload CDAP Standalone and CDAP DEB Bundle
+        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
+        with:
+          repo_token: ${{secrets.GITHUB_TOKEN}}
+          automatic_release_tag: ${{env.TAG_NAME}}
+          files: |
+            cdap-build/cdap/cdap-standalone/target/cdap-sandbox-${{env.CDAP_VERSION}}.zip
+            cdap-build/cdap/cdap-distributions/target/cdap-distributed-deb-bundle-${{env.CDAP_VERSION}}.tgz


### PR DESCRIPTION
Github [schedule](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) workflows only run on latest commit of default branch, so adding a strategy matrix to run the build on both `develop` and `release` branches. Additionally, a support to run the workflow on every branch on manual trigger.