### PR TITLE
Add workflow for deploying cdap-sandbox image to docker hub

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -1,3 +1,14 @@
+# Copyright © 2022 Cask Data, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
 name: Build and Unit Test
 on:
   schedule:

--- a/.github/workflows/cloudbuild.json
+++ b/.github/workflows/cloudbuild.json
@@ -1,0 +1,25 @@
+{
+  "steps": [
+    {
+      "name": "gcr.io/cloud-builders/docker",
+      "entrypoint": "bash",
+      "args": [
+        "-c",
+        "docker build -t caskdata/cdap-sandbox:{{TAG}} cdap/cdap-distributions/src && docker login --username=$$USERNAME --password=$$PASSWORD && docker push caskdata/cdap-sandbox:{{TAG}}"
+      ],
+      "secretEnv": [
+        "USERNAME",
+        "PASSWORD"
+      ]
+    }
+  ],
+  "availableSecrets": {
+    "secretManager": [{
+      "versionName": "projects/cdapio-github-builds/secrets/CASK_DOCKER_HUB_PASSWORD/versions/latest",
+      "env": "PASSWORD"
+    }, {
+      "versionName": "projects/cdapio-github-builds/secrets/CASK_DOCKER_HUB_USERNAME/versions/latest",
+      "env": "USERNAME"
+    }]
+  }
+}

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,0 +1,125 @@
+# Copyright © 2022 Cask Data, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# This workflow depends on https://github.com/cdapio/cdap-build/releases to download the cdap-sandbox for the particular CDAP Version.
+
+name: Docker Deploy
+on:
+  schedule:
+    - cron: '0 15 * * *'
+  workflow_dispatch:
+    # workaround to run manual trigger for a particular branch
+    inputs:
+      branch:
+        description: "branch name on which workflow will be triggered"
+        required: true
+        default: "develop"
+
+env:
+  TAG_NAME: latest
+
+jobs:
+
+  set-branch-matrix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: set-matrix on schedule run
+        id: set-matrix-on-schedule-run
+        if: github.event_name != 'workflow_dispatch'
+        run: echo "::set-output name=matrix::{\"include\":[{\"branch\":\"feature/develop\"}]}"
+
+      - name: set-matrix on manual trigger
+        id: set-matrix-on-manual-trigger
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "::set-output name=matrix::{\"include\":[{\"branch\":\"${{ github.event.inputs.branch }}\"}]}"
+
+      - name: set-matrix-output
+        id: set-matrix-output
+        run: |
+          if [ -z "$MANUAL_TRIGGER_OUTPUT" ];
+          then
+            echo "::set-output name=matrix::${SCHEDULE_RUN_OUTPUT}"
+          else
+            echo "::set-output name=matrix::${MANUAL_TRIGGER_OUTPUT}"
+          fi
+        env:
+          MANUAL_TRIGGER_OUTPUT: ${{ steps.set-matrix-on-manual-trigger.outputs.matrix }}
+          SCHEDULE_RUN_OUTPUT: ${{ steps.set-matrix-on-schedule-run.outputs.matrix }}
+
+    outputs:
+      matrix: ${{ steps.set-matrix-output.outputs.matrix }}
+
+  docker-deploy:
+    needs: set-branch-matrix
+    runs-on: cdapio-hub-k8-runner
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.set-branch-matrix.outputs.matrix) }}
+
+    steps:
+
+      - name: Recursively Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          path: cdap-build
+          ref: ${{ matrix.branch }}
+
+      - name: Update Submodules
+        working-directory: cdap-build
+        run: |
+          git submodule update --init --recursive --remote
+
+      - name: Cache
+        uses: actions/cache@v2.1.3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-${{ github.workflow }}
+
+      - name: Set up CDAP Version
+        working-directory: cdap-build/cdap
+        run: |
+          export VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "CDAP_VERSION=${VERSION}"
+          echo "CDAP_VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Set up TAG name
+        working-directory: cdap-build
+        run: |
+          if [ ${{ matrix.branch }} != "develop" ];
+          then
+            echo "TAG_NAME=v${{ env.CDAP_VERSION }}" >> $GITHUB_ENV  
+            sed -i -e "s#{{TAG}}#${{ env.CDAP_VERSION }}#g" .github/workflows/cloudbuild.json
+          else
+            sed -i -e "s#{{TAG}}#${{ env.TAG_NAME }}#g" .github/workflows/cloudbuild.json
+          fi
+          cat cloudbuild.json
+
+      - name: Set up CDAP SDK with URI
+        working-directory: cdap-build/cdap/cdap-distributions/src
+        run: |
+          sed \
+            -e "s#{{VERSION}}#${{env.CDAP_VERSION}}-1#g" \
+            -e "s#{{URI}}#https://github.com/cdapio/cdap-build/releases/download/${{ env.TAG_NAME }}/cdap-sandbox-${{ env.CDAP_VERSION }}.zip#g" \
+          packer/files/cdap-sdk-with-uri.json.template > packer/files/cdap-sdk.json
+          cat packer/files/cdap-sdk.json
+          chmod +x packer/scripts/*.sh
+          mkdir -p ../target
+
+      - name: Trigger Cloud Build
+        working-directory: cdap-build
+        run: |
+          gcloud builds submit --config cloudbuild.json . --timeout=1800s


### PR DESCRIPTION
This workflow pushes the cdap-sandbox image to docker hub using cloud build after downloading the cdap-sandbox from cdap-build releases.

Example run - https://github.com/cdapio/cdap-build/runs/7857844547?check_suite_focus=true