### PR TITLE
Change number of threads used to run tests to 3

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Run Tests
         working-directory: cdap-build
-        run: MAVEN_OPTS="-Xmx16G -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/cdap-build/oom.bin" mvn test -Drat.skip=true -fae -T2C -U -V -am -amd -P templates,unit-tests --fail-at-end -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
+        run: MAVEN_OPTS="-Xmx16G -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/cdap-build/oom.bin" mvn test -Drat.skip=true -fae -T3 -U -V -am -amd -P templates,unit-tests --fail-at-end -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
 
       - name: Archive build artifacts
         uses: actions/upload-artifact@v2.2.2
@@ -129,7 +129,7 @@ jobs:
 
       - name: Build Standalone
         working-directory: cdap-build
-        run: MAVEN_OPTS="-Xmx12G" mvn -Drat.skip=true -e -T2C clean package -Dgpg.skip -DskipTests -Ddocker.skip=true -nsu -am -amd -P templates,dist,release -Dadditional.artifacts.dir=$(pwd)/app-artifacts -Dsecurity.extensions.dir=$(pwd)/security-extensions -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
+        run: MAVEN_OPTS="-Xmx12G" mvn -Drat.skip=true -e -T3 clean package -Dgpg.skip -DskipTests -Ddocker.skip=true -nsu -am -amd -P templates,dist,release -Dadditional.artifacts.dir=$(pwd)/app-artifacts -Dsecurity.extensions.dir=$(pwd)/security-extensions -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
 
       - name: Find Build Version
         working-directory: cdap-build/cdap


### PR DESCRIPTION
[CDAP-19550 PreviewDataPipelineTest flakiness causes CDAP BUT to fail in approximately 50-75% runs](https://cdap.atlassian.net/browse/CDAP-19550)

-T2C causes maven to use upto 16 threads on the machines being used to run unit tests. This causes test flakiness when multiple memory intensive modules are tested in parallel.

Tested CDAP build with a few different values of -T arg to find the optimal value.

T3
https://github.com/cdapio/cdap-build/actions/runs/2978432917 (no JVM crash)
https://github.com/cdapio/cdap-build/actions/runs/2978431103 (no JVM crash)
https://github.com/cdapio/cdap-build/actions/runs/2978430617 (no JVM crash)
https://github.com/cdapio/cdap-build/actions/runs/2978428693 (no JVM crash)

T2
https://github.com/cdapio/cdap-build/actions/runs/2977715715 (no JVM crash)
https://github.com/cdapio/cdap-build/actions/runs/2977714323 (no JVM crash)
https://github.com/cdapio/cdap-build/actions/runs/2977713463 (no JVM crash)
https://github.com/cdapio/cdap-build/actions/runs/2977712614 (no JVM crash)

T4
https://github.com/cdapio/cdap-build/actions/runs/2976957089 (no JVM crash)
https://github.com/cdapio/cdap-build/actions/runs/2976956396 (no JVM crash)
https://github.com/cdapio/cdap-build/actions/runs/2976955891 (no JVM crash)
https://github.com/cdapio/cdap-build/actions/runs/2976955170 (JVM crash)

Values greater than T3 cause JVM crashes. Even with T3 the build + tests are almost as fast as T2C so there isn’t a performance hit by reducing the number of threads.

See Jira for more details.