### PR TITLE
Upgrade cache github actions to v3

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -76,7 +76,7 @@ jobs:
           git submodule update --init --recursive --remote
 
       - name: Cache
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -68,7 +68,7 @@ jobs:
           git submodule update --init --recursive --remote
 
       - name: Cache
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}
@@ -87,7 +87,7 @@ jobs:
         run: |
           if [ ${{ matrix.branch }} != "develop" ];
           then
-            echo "TAG_NAME=v${{ env.CDAP_VERSION }}" >> $GITHUB_ENV  
+            echo "TAG_NAME=v${{ env.CDAP_VERSION }}" >> $GITHUB_ENV
             sed -i -e "s#{{TAG}}#${{ env.CDAP_VERSION }}#g" .github/workflows/cloudbuild.json
           else
             sed -i -e "s#{{TAG}}#${{ env.TAG_NAME }}#g" .github/workflows/cloudbuild.json


### PR DESCRIPTION
Recently we started seeing this warning in github action builds that `Node.js 12 actions are deprecated`.

```
Warning: Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/cache, actions/cache

```
This PR helps in upgrading the `actions/cache` to `v3` which has node16 support.

Testing 
- https://github.com/cdapio/cdap-build/actions/runs/3245725320
- https://github.com/cdapio/cdap-build/actions/runs/3245725321