### PR TITLE
Added feature-skip-tests,skip-deploy,keep-existing-release

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -17,13 +17,23 @@ on:
     # workaround to run manual trigger for a particular branch
     inputs:
       branch:
-        description: "branch name on which workflow will be triggered"
+        description: "Branch name on which workflow will be triggered"
         required: true
         default: "develop"
+      skip_tests:
+        description: "Skip running tests for this build"
+        required: true
+        default: "false"
+      keep_existing_release:
+        description: "Do not overwrite the release for versions without snapshot"
+        required: true
+        default: "true"
 
 env:
   TAG_NAME: latest
   PRE_RELEASE: true
+  REPLACE_ARTIFACTS: true
+  REMOVE_ARTIFACTS: true
 
 jobs:
 
@@ -83,19 +93,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-${{ github.workflow }}
 
-      - name: Set up Artifact Name
-        # Removes invalid artifact name characters: ",:,<,>,|,*,?,\,/.
+      - name: Set up Artifact Name # Removes invalid artifact name characters: ",:,<,>,|,*,?,\,/.
+        if: ${{ github.event.inputs.skip_tests != 'true' }} || failure()
         run: |
           name=$(echo -n "${{ matrix.branch }}" | sed -e 's/[ \t:\/\\"<>|*?]/-/g' -e 's/--*/-/g')
           echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
 
       - name: Run Tests
         working-directory: cdap-build
+        if: ${{ github.event.inputs.skip_tests != 'true' }} || failure()
         run: MAVEN_OPTS="-Xmx16G -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/cdap-build/oom.bin" mvn test -Drat.skip=true -fae -T2 -U -V -am -amd -P templates,unit-tests --fail-at-end -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
 
       - name: Archive build artifacts
         uses: actions/upload-artifact@v3
-        if: always()
+        if: ${{ github.event.inputs.skip_tests != 'true' }} || failure()
         with:
           name: Build debug files - ${{ env.ARTIFACT_NAME }}
           path: |
@@ -106,7 +117,7 @@ jobs:
       - name: Surefire Report
         # Pinned 1.0.5 version
         uses: ScaCap/action-surefire-report@ad808943e6bfbd2e6acba7c53fdb5c89534da533
-        if: always()
+        if: ${{ github.event.inputs.skip_tests != 'true' }} || failure()
         with:
           # GITHUB_TOKEN
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -123,12 +134,21 @@ jobs:
           export VERSION=$(ls cdap-standalone/target/cdap-sandbox*zip | cut --delimiter=- --fields="-3" --complement | rev | cut --delimiter="." --fields=1 --complement | rev)
           echo "CDAP_VERSION=${VERSION}"
           echo "CDAP_VERSION=${VERSION}" >> $GITHUB_ENV
-          if [[ $VERSION != *-SNAPSHOT ]];
+          if [[ ($VERSION != *-SNAPSHOT) && ("${{ github.event.inputs.keep_existing_release }}" != "false") ]];
           then
             echo "PRE_RELEASE=false" >> $GITHUB_ENV
+            echo "REPLACE_ARTIFACTS=false" >> $GITHUB_ENV
+            echo "REMOVE_ARTIFACTS=false" >> $GITHUB_ENV
+            echo "Release will not be overwritten if exists."
           else
-            echo "SNAPSHOT VERSION"
+            echo "Release will be overwritten if exists."
           fi
+
+      - name: Upload CDAP Standalone
+        uses: actions/upload-artifact@v3 # https://github.com/actions/upload-artifact#zipped-artifact-downloads
+        with:
+          name: cdap-sandbox-${{env.CDAP_VERSION}}.zip
+          path: cdap-build/cdap/cdap-standalone/target/cdap-sandbox-${{env.CDAP_VERSION}}.zip
 
       - name: Set up GPG conf
         run: |
@@ -142,9 +162,15 @@ jobs:
         env:
           GPG_PRIVATE_KEY: ${{ steps.secrets.outputs.CDAP_GPG_PRIVATE_KEY }}
 
-      - name: Deploy Maven
+      - name: Maven Deploy
         working-directory: cdap-build
-        run: mvn deploy -B -V -DskipTests -DskipLocalStaging=true -Ddocker.skip=true -P templates,dist,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests -Dadditional.artifacts.dir=$(pwd)/app-artifacts -Dsecurity.extensions.dir=$(pwd)/security-extensions -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dgpg.passphrase=$CDAP_GPG_PASSPHRASE
+        run: |
+          if [[ (${{ matrix.branch }} == "develop") || (${{ matrix.branch }} == release/*) ]];
+          then
+            mvn deploy -B -V -DskipTests -DskipLocalStaging=true -Ddocker.skip=true -P templates,dist,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests -Dadditional.artifacts.dir=$(pwd)/app-artifacts -Dsecurity.extensions.dir=$(pwd)/security-extensions -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dgpg.passphrase=$CDAP_GPG_PASSPHRASE
+          else
+            mvn verify -B -V -T2 -DskipTests -Dgpg.skip -Ddocker.skip=true -P templates,dist,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests -Dadditional.artifacts.dir=$(pwd)/app-artifacts -Dsecurity.extensions.dir=$(pwd)/security-extensions -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+          fi
         env:
           CDAP_OSSRH_USERNAME: ${{ steps.secrets.outputs.CDAP_OSSRH_USERNAME }}
           CDAP_OSSRH_PASSWORD: ${{ steps.secrets.outputs.CDAP_OSSRH_PASSWORD }}
@@ -159,25 +185,36 @@ jobs:
           cp ../../../*/target/*.deb .
           tar zcf ../cdap-distributed-deb-bundle-${{env.CDAP_VERSION}}.tgz *.deb
 
-      - name: Set up Tag
+      - name: Set Up Tag
         working-directory: cdap-build
         run: |
-          if [ ${{ matrix.branch }} != "develop" ];
+          if [[ ${{ matrix.branch }} == release/* ]];
           then
             echo "TAG_NAME=v$CDAP_VERSION" >> $GITHUB_ENV
             echo "TAG_NAME=v$CDAP_VERSION"
-            git tag -f v$CDAP_VERSION
+            git tag -f v$CDAP_VERSION    
+          elif [[ ${{ matrix.branch }} != "develop" ]];
+          then
+            export TAG=$(git check-ref-format --normalize "tags/${{ matrix.branch }}/tag" | cut -c6- | rev | cut -c5- | rev)
+            echo "TAG_NAME=$TAG" >> $GITHUB_ENV
+            echo "TAG_NAME=$TAG"
+            git tag -f $TAG
           else
             git tag -f ${{ env.TAG_NAME }}
           fi
           git push -f origin --tags
 
       - name: Upload CDAP Standalone and CDAP DEB Bundle
-        uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37
+        # Pinned 1.11.1 version
+        uses: ncipollo/release-action@4c75f0f2e4ae5f3c807cf0904605408e319dcaac
         with:
           allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
           prerelease: ${{ env.PRE_RELEASE }}
-          replacesArtifacts: true
+          removeArtifacts: ${{ env.REMOVE_ARTIFACTS }}
+          replacesArtifacts: ${{ env.REPLACE_ARTIFACTS }}
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.TAG_NAME }}
           body: Cask Data Appplication Platform - Release ${{ env.CDAP_VERSION }}


### PR DESCRIPTION
- Upgraded `ncipollo/release-action` to `v1.11.1` which has `node16` support.
- Added capability of triggering testless build manually.
- Skip `mvn deploy` if branch is not `develop` or `release/*`.
- Do not overwrite release by default for non-snapshot versions.