### PR TITLE
Change debian repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ARG EXTEND_DEFAULT_CONFIGS=false
 ARG CONFIG_FILE_NAME
 WORKDIR $DIR/
 COPY . $DIR/
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
 RUN tar -zcvf cdap-build-sources.tar.gz --exclude='.git*' --exclude='node_modules' --exclude='target' --exclude-vcs \
         --exclude-vcs-ignores app-artifacts cdap eventwriters-extensions metricswriters-extensions security-extensions \
         Dockerfile LICENSE.txt README.md && \


### PR DESCRIPTION
Change debian repo due to changes in debian repo: https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html

using http://archive.debian.org/debian as per:
https://unix.stackexchange.com/questions/743839/apt-get-update-failed-to-fetch-debian-amd64-packages-while-building-dockerfile-f