### PR TITLE
update maven image to fix CDAP build failure

### DIFF
--- a/maven.Dockerfile
+++ b/maven.Dockerfile
@@ -15,7 +15,7 @@
 
 # Dockerfile for building container for building CDAP.
 # It populate maven cache with dependencies needed for building CDAP.
-FROM gcr.io/cloud-builders/mvn:3.5.0-jdk-8 AS build
+FROM gcr.io/cloud-builders/mvn:3.8-jdk-8 AS build
 ENV MAVEN_OPTS -Xmx4096m -Dhttp.keepAlive=false
 WORKDIR /cdap/maven/
 COPY . /cdap/maven/


### PR DESCRIPTION
context:

CDAP UI Build failing with error: 

```
"build-docker": [ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.15.0:install-node-and-yarn (dist) on project cdap-ui: The plugin com.github.eirslett:frontend-maven-plugin:1.15.0 requires Maven version 3.6.0 -> [Help 1]
```