### PR TITLE
omit apt-transport-https package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.
 RUN tar -zcvf cdap-build-sources.tar.gz --exclude='.git*' --exclude='node_modules' --exclude='target' --exclude-vcs \
         --exclude-vcs-ignores app-artifacts cdap eventwriters-extensions metricswriters-extensions security-extensions \
         Dockerfile LICENSE.txt README.md && \
-    apt-get update && apt-get install -y lsb-release && apt-get install -y apt-transport-https && \
+    apt-get update && apt-get install -y lsb-release && \
     DISTRO="$(lsb_release -s -c)" && \
     echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_10.x ${DISTRO} main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
     curl https://deb.nodesource.com/gpgkey/nodesource.gpg.key -o /usr/share/keyrings/nodesource.gpg.key && \


### PR DESCRIPTION
context:

`apt-get install -y apt-transport-https` fails with error:

```
The following packages have unmet dependencies:
 dpkg : Breaks: libapt-pkg5.0 (< 1.7~b) but 1.4.10 is to be installed
```
In most modern systems, the apt-transport-https package is no longer required explicitly because support for HTTPS is built directly into APT by default starting from APT version 1.5 (released in 2017). Most newer versions of Ubuntu and Debian include HTTPS support in APT without needing the separate apt-transport-https package.