### PR TITLE
Changed Dockerfile to resolve version conflict for libapt-pkg5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,17 @@ ARG EXTEND_DEFAULT_CONFIGS=false
 ARG CONFIG_FILE_NAME
 WORKDIR $DIR/
 COPY . $DIR/
-RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y curl make && \
+    curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n && \
+    bash n 10.24.1 && \
+    npm install -g n && \
+    n 10.24.1
+
 RUN tar -zcvf cdap-build-sources.tar.gz --exclude='.git*' --exclude='node_modules' --exclude='target' --exclude-vcs \
         --exclude-vcs-ignores app-artifacts cdap eventwriters-extensions metricswriters-extensions security-extensions \
         Dockerfile LICENSE.txt README.md && \
-    apt-get update && apt-get install -y lsb-release && \
-    DISTRO="$(lsb_release -s -c)" && \
-    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_10.x ${DISTRO} main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
-    curl https://deb.nodesource.com/gpgkey/nodesource.gpg.key -o /usr/share/keyrings/nodesource.gpg.key && \
-    apt-key --keyring /usr/share/keyrings/nodesource.gpg add /usr/share/keyrings/nodesource.gpg.key && \
-    # installation of nodejs expects /bin/bash instead of /bin/sh
-    apt-get update && /bin/bash -c 'apt-get -y install nodejs' && \
     mvn install -f cdap -B -V -Ddocker.skip=true -DskipTests -P 'templates,!unit-tests' && \
     mvn install -B -V -Ddocker.skip=true -DskipTests -P 'templates,dist,k8s,!unit-tests' \
       -Dadditional.artifacts.dir="$DIR/app-artifacts" \


### PR DESCRIPTION
When trying to build a dockerimage for CDAP 6.10.1, I received following error during the build process:

The following packages have unmet dependencies:
 dpkg : Breaks: libapt-pkg5.0 (< 1.7~b) but 1.4.11 is to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
The command '/bin/sh -c tar -zcvf cdap-build-sources.tar.gz --exclude='.git*' --exclude='node_modules' --exclude='target' --exclude-vcs         --exclude-vcs-ignores app-artifacts cdap eventwriters-extensions metricswriters-extensions security-extensions         Dockerfile LICENSE.txt README.md &&     apt-get update && apt-get install -y lsb-release && apt-get install -y apt-transport-https &&     DISTRO="$(lsb_release -s -c)" &&     echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_10.x ${DISTRO} main" | tee -a /etc/apt/sources.list.d/nodesource.list &&     curl https://deb.nodesource.com/gpgkey/nodesource.gpg.key -o /usr/share/keyrings/nodesource.gpg.key &&     apt-key --keyring /usr/share/keyrings/nodesource.gpg add /usr/share/keyrings/nodesource.gpg.key &&     apt-get update && /bin/bash -c 'apt-get -y install nodejs' &&     mvn install -f cdap -B -V -Ddocker.skip=true -DskipTests -P 'templates,!unit-tests' &&     mvn install -B -V -Ddocker.skip=true -DskipTests -P 'templates,dist,k8s,!unit-tests'       -Dadditional.artifacts.dir="$DIR/app-artifacts"       -Dsecurity.extensions.dir="$DIR/security-extensions"       -Dmetricswriters.extensions.dir="$DIR/metricswriters-extensions"       -Deventwriters.extensions.dir="$DIR/eventwriters-extensions"       -Dextend-default-configs="$EXTEND_DEFAULT_CONFIGS" -Dconfig-path="$DIR/$CONFIG_FILE_NAME"       -Dui.build.name=cdap-non-optimized-full-build' returned a non-zero code: 100

I was able to solve the problem with the adjustments I made to the Dockerfile. The main changes are in the build stage where I've:

- Removed the problematic NodeSource repository setup
- Added the n version manager installation
- Installed Node.js 10.24.1 using n