### PR TITLE
Retry both on error & timeout in case of failures

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           timeout_minutes: 120
           max_attempts: ${{ needs.set-branch-matrix.outputs.retries }}
-          retry_on: error
+          retry_on: any
           on_retry_command: echo "Tests failed in this attempt, retrying ..."
           command: |
             cd cdap-build
@@ -162,7 +162,7 @@ jobs:
         with:
           timeout_minutes: 60
           max_attempts: 3
-          retry_on: error
+          retry_on: any
           on_retry_command: echo "Build Standalone failed in this attempt, retrying ..."
           command: |
               cd cdap-build


### PR DESCRIPTION
context: We are seeing some intermittent failures where some steps like `Build Standalone` can also fail with timeout, adding retry for it so that we don't end up running whole step for such failures.

![image](https://github.com/user-attachments/assets/2d48964e-6b40-446a-9fb4-8619e9691d5a)