### PR TITLE
CDAP OSS migration for cdap-build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,14 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
+        <extensions>true</extensions>
         <configuration>
-          <skip>true</skip>
+          <publishingServerId>sonatype.release</publishingServerId>
+          <autoPublish>false</autoPublish>
+          <ignorePublishedComponents>true</ignorePublishedComponents>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Validated that there are no plugins of type maven-release-plugin, maven-deploy-plugin and nexus-staging-maven-plugin in the repository.